### PR TITLE
Window object and information methods.

### DIFF
--- a/src/hofx/tools.py
+++ b/src/hofx/tools.py
@@ -38,12 +38,14 @@ def replace_vars(config):
 class Window:
 
     def __init__(self, config):
+        self._config = config
         self.window_length = DateIncrement(config.get('window_length', 'PT6H')) # length of the assimilation window (beginning to end)
         self.window_offset = DateIncrement(config.get('window_offset', 'PT3H')) # offset from end of the window to "analysis time"
         self.step_cycle = DateIncrement(config.get('step_cycle', 'PT6H')) # Cadence
         self.window_type = config.get('window_type', '3d') # 3D or 4D windows
         self.bg_frequency= DateIncrement(config.get('bg_frequency', self.step_cycle)) # Frequency of backgrounds
         self.bg_step= DateIncrement(config.get('bg_step', self.step_cycle)) # Cadence
+        self.info
 
     @property
     def info(self):
@@ -58,7 +60,7 @@ class Window:
 
     @staticmethod
     def analysis_time(current_date):
-        return current_date
+        return str(JediDate(current_date))
 
     def window_end(self, current_date):
         return str(JediDate(current_date) + self.window_offset)


### PR DESCRIPTION
Add `Window` class that provides details of the assimilation window

input is a dictionary `config`. Defaults are:

```
window_length = 'PT6H'
window_offset =  'PT3H'
step_cycle =  'PT6H'
window_type = '3d' # 3d|4d
bg_frequency= 'PT6H' # default is step_cycle. For 4D hourly sub-windows, e.g. 'PT1H'
bg_step= 'PT6H' # default is step_cycle. GEOS requires it to be PT9H.  Don't ask why.
```

Usage:

```
import hofx

# Construct the 4d window object.
win4d = hofx.tools.Window(config=dict(window_type='4d', bg_frequency='PT1H'))

# Get the window details for the current cycle time (CDATE).
cfg4d = win4d.details('2021-06-20T12:00:00Z')
print(cfg4d)

print(win4d.analysis_time('2021-06-20T12:00:00Z'))
print(win4d.analysis_time('2021062018'))
```

Should produce output sucha s this:
```
Information about the Window object:
	window_length = PT6H
	window_offset = PT3H
	window_type   = 4d
	step_cycle    = PT6H
	bg_frequency  = PT1H
	bg_step       = PT6H
{'window_begin': '2021-06-20T09:00:00Z', 'window_end': '2021-06-20T15:00:00Z', 'background_steps': ['PT3H', 'PT4H', 'PT5H', 'PT6H', 'PT7H', 'PT8H', 'PT9H']}
2021-06-20T12:00:00Z
2021-06-20T18:00:00Z
```