### PR TITLE
Changes to reflect changes in FV3-JEDI ewok dir

### DIFF
--- a/src/hofx/bin/genYAML
+++ b/src/hofx/bin/genYAML
@@ -39,6 +39,7 @@ def gen_yaml(task, expdir, yamlout):
     win_details['current_cycle'] = anl_time
     win_details['background_time'] = bg_time
     win_details['local_current_cycle'] = dt.datetime.strptime(anl_time, '%Y-%m-%dT%H:%M:%SZ').strftime('%Y%m%d.%H%M%S')
+    win_details['local_background_time'] = dt.datetime.strptime(anl_time, '%Y-%m-%dT%H:%M:%SZ').strftime('%Y%m%d.%H%M%S')
     # solo does weird things with certain derived types, forcing to strings
     win_details['window_length'] = f'{window.window_length}'
     win_details['window_offset'] = f'{window.window_offset}'

--- a/src/hofx/cfg/expdir/experiment.yaml
+++ b/src/hofx/cfg/expdir/experiment.yaml
@@ -42,7 +42,7 @@ npy_ufs: 769
 npz_ufs: $(vertical_resolution)
 ntiles_ufs: 6
 # end what should be computed
-current_dir: $(experiment_dir)/{{current_cycle}}/RESTART
+run_dir: $(experiment_dir)/{{current_cycle}}/RESTART
 account: da-cpu
 obs_dir: $(experiment_dir)/{{cycle}}
 obs_db: ufo_eval_ref


### PR DESCRIPTION
Closes #30.

This changes `current_dir` to `run_dir` so that the H(x) executable can find the model backgrounds properly.
It also adds `local_background_time` to be equal to the `local_current_cycle`. I think this will need fixed/changed eventually as it might need to be more adaptable if there is 4D H(x) but I am not sure.