### PR TITLE
bugfix to split channels in yaml more robustly

### DIFF
--- a/src/hofx/diag/plotIODA.py
+++ b/src/hofx/diag/plotIODA.py
@@ -39,7 +39,7 @@ class IODAdiagnostic:
         Creates a list of inputted channels as integers from string.
         """
 
-        changroups = channels.split(', ')
+        changroups = [c.strip() for c in channels.split(',')]
         inputchans = []
 
         for c in changroups:


### PR DESCRIPTION
Should not matter how many spaces (none or several), will return list of split channels.