### PR TITLE
merge feature/clean into develop

### DIFF
--- a/src/hofx/cfg/expdir/experiment.yaml
+++ b/src/hofx/cfg/expdir/experiment.yaml
@@ -6,6 +6,7 @@
 #  emcpy_homedir:  path to src directory of emcpy clone
 #  wrkdir:  directory to which cycled output files are written
 #  expxmldir:  directory to which xml file is written
+#  keepdata:  retain (yes) or remove (no) directories/files in wrkdir upon completion of each cycle
 expname: 'prhofx'
 begdate: '2020121500'
 enddate: '2020121600'
@@ -13,6 +14,7 @@ hofx_homedir: '/work/noaa/da/rtreadon/git/hofxcs/develop/src'  # change to your 
 emcpy_homedir: '/work/noaa/da/rtreadon/git/emcpy/src'          # change to your path
 wrkdir: '/work/noaa/stmp/rtreadon/rocoto'                      # change to your path
 expxmldir: '/work/noaa/da/rtreadon/para_gfs/prhofx'            # change to your path
+keepdata: 'no'       
 #
 # Set bundle and jedi_bundle dpending on machine
 ##bundle: /scratch1/NCEPDEV/da/Cory.R.Martin/JEDI/testing/intel/bundle
@@ -68,4 +70,35 @@ diag_types:
 - spatial_ufoomf
 obs_list:
 - $<< $(bundle)/ufo/ewok/jedi-gdas/aircraft.yaml
+#- $<< $(bundle)/ufo/ewok/jedi-gdas/airs_aqua.yaml       # not available for test period
+#- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_aqua.yaml      # not available for test period
+- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_metop-a.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_metop-b.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_metop-c.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_n15.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_n18.yaml
 - $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_n19.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/atms_n20.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/atms_npp.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/avhrr3_metop-a.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/avhrr3_n18.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/cris-fsr_n20.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/cris-fsr_npp.yaml
+#- $<< $(bundle)/ufo/ewok/jedi-gdas/gnssrobndnbam.yaml   # not available for test period
+- $<< $(bundle)/ufo/ewok/jedi-gdas/iasi_metop-a.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/iasi_metop-b.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/mhs_metop-b.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/mhs_metop-c.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/mhs_n19.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/omi_aura.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/ompsnp_npp.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/ompstc8_npp.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/rass_tv.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/satwind.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/scatwind.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/seviri_m11.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/sfc.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/sfcship.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/sondes.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/ssmis_f17.yaml
+- $<< $(bundle)/ufo/ewok/jedi-gdas/vadwind.yaml

--- a/src/hofx/cfg/expdir/experiment.yaml
+++ b/src/hofx/cfg/expdir/experiment.yaml
@@ -10,7 +10,7 @@
 expname: 'prhofx'
 begdate: '2020121500'
 enddate: '2020121600'
-hofx_homedir: '/work/noaa/da/rtreadon/git/hofxcs/develop/src'  # change to your path
+hofx_homedir: '/work/noaa/da/rtreadon/git/JEDI-Eval/develop/src'  # change to your path
 emcpy_homedir: '/work/noaa/da/rtreadon/git/emcpy/src'          # change to your path
 wrkdir: '/work/noaa/stmp/rtreadon/rocoto'                      # change to your path
 expxmldir: '/work/noaa/da/rtreadon/para_gfs/prhofx'            # change to your path
@@ -71,35 +71,4 @@ diag_types:
 - spatial_ufoomf
 obs_list:
 - $<< $(bundle)/ufo/ewok/jedi-gdas/aircraft.yaml
-#- $<< $(bundle)/ufo/ewok/jedi-gdas/airs_aqua.yaml       # not available for test period
-#- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_aqua.yaml      # not available for test period
-- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_metop-a.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_metop-b.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_metop-c.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_n15.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_n18.yaml
 - $<< $(bundle)/ufo/ewok/jedi-gdas/amsua_n19.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/atms_n20.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/atms_npp.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/avhrr3_metop-a.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/avhrr3_n18.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/cris-fsr_n20.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/cris-fsr_npp.yaml
-#- $<< $(bundle)/ufo/ewok/jedi-gdas/gnssrobndnbam.yaml   # not available for test period
-- $<< $(bundle)/ufo/ewok/jedi-gdas/iasi_metop-a.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/iasi_metop-b.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/mhs_metop-b.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/mhs_metop-c.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/mhs_n19.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/omi_aura.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/ompsnp_npp.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/ompstc8_npp.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/rass_tv.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/satwind.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/scatwind.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/seviri_m11.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/sfc.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/sfcship.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/sondes.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/ssmis_f17.yaml
-- $<< $(bundle)/ufo/ewok/jedi-gdas/vadwind.yaml

--- a/src/hofx/cfg/templates/hofx.xml
+++ b/src/hofx/cfg/templates/hofx.xml
@@ -24,6 +24,7 @@
 	<!-- Work directory -->
         <!ENTITY WRKDIR "wrkdir">
 	<!ENTITY ROTDIR "&WRKDIR;/&PSLOT;">
+        <!ENTITY KEEPDATA "keepdata">
 
         <!-- HOFX and EMCPY directories -->
         <!ENTITY HOFX_HOMEDIR "hofx_homedir">
@@ -45,14 +46,14 @@
 
 	<!ENTITY QUEUE_STAGE_GDAS     "&QUEUE;">
 	<!ENTITY PARTITION_STAGE_GDAS "&PARTITION_BATCH;">
-	<!ENTITY WALLTIME_STAGE_GDAS  "00:15:00">
+	<!ENTITY WALLTIME_STAGE_GDAS  "00:30:00">
 	<!ENTITY RESOURCES_STAGE_GDAS "<nodes>1:ppn=1:tpp=1</nodes>">
 	<!ENTITY NATIVE_STAGE_GDAS    "--export=NONE">
 
 	<!ENTITY QUEUE_HOFX_GDAS     "&QUEUE;">
 	<!ENTITY PARTITION_HOFX_GDAS "&PARTITION_BATCH;">
-	<!ENTITY WALLTIME_HOFX_GDAS  "00:30:00">
-	<!ENTITY RESOURCES_HOFX_GDAS "<nodes>8:ppn=3:tpp=1</nodes>">
+	<!ENTITY WALLTIME_HOFX_GDAS  "01:00:00">
+	<!ENTITY RESOURCES_HOFX_GDAS "<nodes>2:ppn=12:tpp=1</nodes>">
 	<!ENTITY NATIVE_HOFX_GDAS    "--export=NONE">
 
 	<!ENTITY QUEUE_MERGE_GDAS     "&QUEUE;">
@@ -69,7 +70,7 @@
 
 	<!ENTITY QUEUE_DIAGS_GDAS     "&QUEUE;">
 	<!ENTITY PARTITION_DIAGS_GDAS "&PARTITION_BATCH;">
-	<!ENTITY WALLTIME_DIAGS_GDAS  "00:15:00">
+	<!ENTITY WALLTIME_DIAGS_GDAS  "01:15:00">
 	<!ENTITY RESOURCES_DIAGS_GDAS "<nodes>1:ppn=1:tpp=1</nodes>">
 	<!ENTITY NATIVE_DIAGS_GDAS    "--export=NONE">
 
@@ -195,6 +196,7 @@
         <envar><name>machine</name><value>&machine;</value></envar>
         <envar><name>HOFX_HOMEDIR</name><value>&HOFX_HOMEDIR;</value></envar>
         <envar><name>ROTDIR</name><value>&ROTDIR;</value></envar>
+        <envar><name>KEEPDATA</name><value>&KEEPDATA;</value></envar>
 	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
 
 	<dependency>
@@ -226,6 +228,7 @@
         <envar><name>HOFX_HOMEDIR</name><value>&HOFX_HOMEDIR;</value></envar>
         <envar><name>EMCPY_HOMEDIR</name><value>&EMCPY_HOMEDIR;</value></envar>
         <envar><name>ROTDIR</name><value>&ROTDIR;</value></envar>
+        <envar><name>KEEPDATA</name><value>&KEEPDATA;</value></envar>
 	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
 
 	<dependency>

--- a/src/hofx/rocoto/gdas_archive.sh
+++ b/src/hofx/rocoto/gdas_archive.sh
@@ -4,6 +4,15 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR
 
-$HOFX_HOMEDIR/hofx/scripts/archive.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp
+$HOFX_HOMEDIR/hofx/scripts/archive.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
+
+# If requested, remove stage directory for current cycle 
+KEEPDATA=$(echo ${KEEPDATA:-"NO"} | tr a-z A-Z)
+if [[ $KEEPDATA = "NO" ]]; then
+    string=`grep "cycle" $ROTDIR/hofx_tmp/$CDATE/archive.yaml | cut -d "'" -f2-2 | head -1`
+    DATAROOT=$ROTDIR/${string}
+    [[ -d $DATAROOT ]] && rm -rf $DATAROOT
+fi
+
 exit $rc

--- a/src/hofx/rocoto/gdas_diags.sh
+++ b/src/hofx/rocoto/gdas_diags.sh
@@ -13,7 +13,6 @@ if [[ $KEEPDATA = "NO" ]]; then
     string=`grep "window begin" $ROTDIR/hofx_tmp/$CDATE/diags.yaml | cut -d "'" -f2-2 | head -1`
     RMFILES=$ROTDIR/diags/*${string}.nc4
     rm -rf $RMFILES
-#   rm -r $ROTDIR/hofx_tmp/$CDATE
 fi
 
 exit $rc

--- a/src/hofx/rocoto/gdas_diags.sh
+++ b/src/hofx/rocoto/gdas_diags.sh
@@ -4,6 +4,16 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR:$EMCPY_HOMEDIR
 
-$HOFX_HOMEDIR/hofx/scripts/diags.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp
+$HOFX_HOMEDIR/hofx/scripts/diags.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
+
+# If requested, remove files in $ROTDIR/diags for current cycle
+KEEPDATA=$(echo ${KEEPDATA:-"NO"} | tr a-z A-Z)
+if [[ $KEEPDATA = "NO" ]]; then
+    string=`grep "window begin" $ROTDIR/hofx_tmp/$CDATE/diags.yaml | cut -d "'" -f2-2 | head -1`
+    RMFILES=$ROTDIR/diags/*${string}.nc4
+    rm -rf $RMFILES
+#   rm -r $ROTDIR/hofx_tmp/$CDATE
+fi
+
 exit $rc

--- a/src/hofx/rocoto/gdas_hofx.sh
+++ b/src/hofx/rocoto/gdas_hofx.sh
@@ -4,6 +4,6 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR
 
-$HOFX_HOMEDIR/hofx/scripts/hofx.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp
+$HOFX_HOMEDIR/hofx/scripts/hofx.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
 exit $rc

--- a/src/hofx/rocoto/gdas_merge.sh
+++ b/src/hofx/rocoto/gdas_merge.sh
@@ -4,6 +4,6 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR
 
-$HOFX_HOMEDIR/hofx/scripts/merge.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp
+$HOFX_HOMEDIR/hofx/scripts/merge.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
 exit $rc

--- a/src/hofx/rocoto/gdas_stage.sh
+++ b/src/hofx/rocoto/gdas_stage.sh
@@ -4,6 +4,6 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR
 
-$HOFX_HOMEDIR/hofx/scripts/stage.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp
+$HOFX_HOMEDIR/hofx/scripts/stage.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
 exit $rc

--- a/src/hofx/rocoto/setup_workflow.py
+++ b/src/hofx/rocoto/setup_workflow.py
@@ -53,6 +53,9 @@ def setup_workflow(expyaml):
     search_key='expxmldir'
     expxmldir=set_key(search_key,parsed_expyml)
 
+    search_key='keepdata'
+    keepdata=set_key(search_key,parsed_expyml)
+
 
     # Load extracte values into list.  Echo values to stdout
     replacements = {
@@ -64,6 +67,7 @@ def setup_workflow(expyaml):
         'wrkdir': wrkdir,
         'platform': machine,
         'expxmldir': expxmldir,
+        'keepdata': keepdata,
        }
 
     print(' ')


### PR DESCRIPTION
Issue #37 documents the changes in `feature/clean`.   This branch does not alter hofxcs results.  It simply cleans up files and directories which are no longer needed as the workflow cycles along.   Users may turn off directory cleanup by setting variable `keepdata` to `yes` (ie, _yes, keep the data_) in `src/hofx/cfgs/expdir/experiment.yaml`.   As currently configured, `keepdata` defaults to `no` (remove directories and files).

Two additional changes are in this PR.   
- write yaml files for each cycle to cycle specific directories.  This prevents jobs from one cycle overwriting the yaml files from jobs in another cycle.
- job configuration changes in the workflow:  (1) run `gdas_hofx` on 2 nodes instead of 8 nodes (still 24 tasks), (2) increase wall time for `gdas_stage`, `gdas_hofx`, and `gdas_diags`.   Change (2) was made to cover the case in which all available observation types are processed.