### PR TITLE
Feature/clean refactor

### DIFF
--- a/src/hofx/bin/source_yaml
+++ b/src/hofx/bin/source_yaml
@@ -6,9 +6,11 @@ if len(sys.argv) < 2:
     exit(1)
 
 config = YAMLFile(sys.argv[1])
-if len(sys.argv) > 4:
+if len(sys.argv) >= 4:
     for key in sys.argv[3:]:
-        print(f'{key}="{config[sys.argv[2]][key]}"')
+        key_clean = key.replace(' ', '_')
+        print(f'{key_clean}="{config[sys.argv[2]][key]}"')
 else:
    key = sys.argv[2]
-   print(f'{key}="{config[key]}"')
+   key_clean = key.replace(' ', '_')
+   print(f'{key_clean}="{config[key]}"')

--- a/src/hofx/cfg/platform/orion/JEDI
+++ b/src/hofx/cfg/platform/orion/JEDI
@@ -14,6 +14,6 @@ make_cmd="make -j8"
 #ecbuild_cmd="ecbuild -DMPIEXEC_EXECUTABLE=/opt/slurm/bin/srun -DMPIEXEC_NUMPROC_FLAG='-n' -DBUILD_PYTHON_BINDINGS=ON -DBUILD_IODA_CONVERTERS=ON"
 ecbuild_cmd="ecbuild -DMPIEXEC_EXECUTABLE=/opt/slurm/bin/srun -DMPIEXEC_NUMPROC_FLAG='-n'"
 scheduler="slurm"
-APRUN="srun --export=ALL"
+export APRUN="srun --export=ALL"
 
 export PYTHONPATH=$PYTHONPATH:/work/noaa/da/cmartin/JEDI/ioda-bundle/build/lib/python3.7

--- a/src/hofx/cfg/setup
+++ b/src/hofx/cfg/setup
@@ -1,4 +1,4 @@
-export PYTHONPATH=$HOFX_HOMEDIR:$EMCPY_HOMEDIR
+export PYTHONPATH=$HOFX_HOMEDIR
 
 #---- other variables
 alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml

--- a/src/hofx/cfg/setup
+++ b/src/hofx/cfg/setup
@@ -1,0 +1,14 @@
+export PYTHONPATH=$HOFX_HOMEDIR:$EMCPY_HOMEDIR
+
+#---- other variables
+alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
+alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
+alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
+shopt -s expand_aliases
+
+#---- get machine and setup runtime environment
+set +eux
+machine=${machine:-$(detect_host)}
+source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
+export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
+set -eux

--- a/src/hofx/rocoto/gdas_archive.sh
+++ b/src/hofx/rocoto/gdas_archive.sh
@@ -10,8 +10,15 @@ rc=$?
 # If requested, remove stage directory for current cycle 
 KEEPDATA=$(echo ${KEEPDATA:-"NO"} | tr a-z A-Z)
 if [[ $KEEPDATA = "NO" ]]; then
-    string=`grep "cycle" $ROTDIR/hofx_tmp/$CDATE/archive.yaml | cut -d "'" -f2-2 | head -1`
-    DATAROOT=$ROTDIR/${string}
+    alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
+    shopt -s expand_aliases
+
+    set +eux
+    source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
+    set -eux
+
+    eval $(source_yaml ${ROTDIR}/hofx_tmp/${CDATE}/archive.yaml archive cycle )
+    DATAROOT=$ROTDIR/${cycle}
     [[ -d $DATAROOT ]] && rm -rf $DATAROOT
 fi
 

--- a/src/hofx/rocoto/gdas_archive.sh
+++ b/src/hofx/rocoto/gdas_archive.sh
@@ -4,19 +4,26 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR
 
+#---- other variables
+alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
+alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
+alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
+shopt -s expand_aliases
+
+#---- get machine and setup runtime environment
+set +eux
+machine=${machine:-$(detect_host)}
+source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
+export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
+set -eux
+
+#---- execute archive
 $HOFX_HOMEDIR/hofx/scripts/archive.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
 
-# If requested, remove stage directory for current cycle 
+#---- if requested, remove stage directory for current cycle 
 KEEPDATA=$(echo ${KEEPDATA:-"NO"} | tr a-z A-Z)
 if [[ $KEEPDATA = "NO" ]]; then
-    alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
-    shopt -s expand_aliases
-
-    set +eux
-    source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
-    set -eux
-
     eval $(source_yaml ${ROTDIR}/hofx_tmp/${CDATE}/archive.yaml archive cycle )
     DATAROOT=$ROTDIR/${cycle}
     [[ -d $DATAROOT ]] && rm -rf $DATAROOT

--- a/src/hofx/rocoto/gdas_archive.sh
+++ b/src/hofx/rocoto/gdas_archive.sh
@@ -2,20 +2,8 @@
 
 set -eux
 
-export PYTHONPATH=$HOFX_HOMEDIR
-
-#---- other variables
-alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
-alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
-alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
-export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
-set -eux
+#---- setup runtime evironment
+source $HOFX_HOMEDIR/hofx/cfg/setup
 
 #---- execute archive
 $HOFX_HOMEDIR/hofx/scripts/archive.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE

--- a/src/hofx/rocoto/gdas_diags.sh
+++ b/src/hofx/rocoto/gdas_diags.sh
@@ -10,8 +10,15 @@ rc=$?
 # If requested, remove files in $ROTDIR/diags for current cycle
 KEEPDATA=$(echo ${KEEPDATA:-"NO"} | tr a-z A-Z)
 if [[ $KEEPDATA = "NO" ]]; then
-    string=`grep "window begin" $ROTDIR/hofx_tmp/$CDATE/diags.yaml | cut -d "'" -f2-2 | head -1`
-    RMFILES=$ROTDIR/diags/*${string}.nc4
+    alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
+    shopt -s expand_aliases
+
+    set +eux
+    source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
+    set -eux
+
+    eval $(source_yaml $ROTDIR/hofx_tmp/$CDATE/diags.yaml plot "window begin")
+    RMFILES=$ROTDIR/diags/*${window_begin}.nc4
     rm -rf $RMFILES
 fi
 

--- a/src/hofx/rocoto/gdas_diags.sh
+++ b/src/hofx/rocoto/gdas_diags.sh
@@ -2,20 +2,8 @@
 
 set -eux
 
-export PYTHONPATH=$HOFX_HOMEDIR:$EMCPY_HOMEDIR
-
-#---- other variables
-alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
-alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
-alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
-export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
-set -eux
+#---- setup runtime evironment
+source $HOFX_HOMEDIR/hofx/cfg/setup
 
 #---- execute diags
 $HOFX_HOMEDIR/hofx/scripts/diags.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE

--- a/src/hofx/rocoto/gdas_diags.sh
+++ b/src/hofx/rocoto/gdas_diags.sh
@@ -4,6 +4,7 @@ set -eux
 
 #---- setup runtime evironment
 source $HOFX_HOMEDIR/hofx/cfg/setup
+export PYTHONPATH=$PYTHONPATH:$EMCPY_HOMEDIR
 
 #---- execute diags
 $HOFX_HOMEDIR/hofx/scripts/diags.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE

--- a/src/hofx/rocoto/gdas_diags.sh
+++ b/src/hofx/rocoto/gdas_diags.sh
@@ -4,19 +4,26 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR:$EMCPY_HOMEDIR
 
+#---- other variables
+alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
+alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
+alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
+shopt -s expand_aliases
+
+#---- get machine and setup runtime environment
+set +eux
+machine=${machine:-$(detect_host)}
+source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
+export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
+set -eux
+
+#---- execute diags
 $HOFX_HOMEDIR/hofx/scripts/diags.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
 
-# If requested, remove files in $ROTDIR/diags for current cycle
+#---- if requested, remove files in $ROTDIR/diags for current cycle
 KEEPDATA=$(echo ${KEEPDATA:-"NO"} | tr a-z A-Z)
 if [[ $KEEPDATA = "NO" ]]; then
-    alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
-    shopt -s expand_aliases
-
-    set +eux
-    source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
-    set -eux
-
     eval $(source_yaml $ROTDIR/hofx_tmp/$CDATE/diags.yaml plot "window begin")
     RMFILES=$ROTDIR/diags/*${window_begin}.nc4
     rm -rf $RMFILES

--- a/src/hofx/rocoto/gdas_hofx.sh
+++ b/src/hofx/rocoto/gdas_hofx.sh
@@ -4,6 +4,32 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR
 
+#---- other variables
+alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
+alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
+alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
+shopt -s expand_aliases
+
+#---- get machine and setup runtime environment
+set +eux
+machine=${machine:-$(detect_host)}
+source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
+export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
+set -eux
+eval $(source_yaml $HOFX_HOMEDIR/hofx/cfg/expdir/experiment.yaml account)
+
+#---- setup variables based on scheduler
+RUN_ENVIR=${RUN_ENVIR:-""}
+if [[ "$RUN_ENVIR" != "rocoto" ]]; then
+  export SLURM_ACCOUNT=$account
+  export SALLOC_ACCOUNT=$SLURM_ACCOUNT
+  export SBATCH_ACCOUNT=$SLURM_ACCOUNT
+  export SLURM_QOS=debug
+  nprocs=24
+  export APRUN="srun -n ${nprocs} --ntasks-per-node=3 -t 30:00"
+fi
+
+#---- execute hofx
 $HOFX_HOMEDIR/hofx/scripts/hofx.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
 exit $rc

--- a/src/hofx/rocoto/gdas_hofx.sh
+++ b/src/hofx/rocoto/gdas_hofx.sh
@@ -2,21 +2,8 @@
 
 set -eux
 
-export PYTHONPATH=$HOFX_HOMEDIR
-
-#---- other variables
-alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
-alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
-alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
-export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
-set -eux
-eval $(source_yaml $HOFX_HOMEDIR/hofx/cfg/expdir/experiment.yaml account)
+#---- setup runtime evironment
+source $HOFX_HOMEDIR/hofx/cfg/setup
 
 #---- setup variables based on scheduler
 RUN_ENVIR=${RUN_ENVIR:-""}

--- a/src/hofx/rocoto/gdas_merge.sh
+++ b/src/hofx/rocoto/gdas_merge.sh
@@ -4,6 +4,20 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR
 
+#---- other variables
+alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
+alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
+alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
+shopt -s expand_aliases
+
+#---- get machine and setup runtime environment
+set +eux
+machine=${machine:-$(detect_host)}
+source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
+export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
+set -eux
+
+#---- execute merge
 $HOFX_HOMEDIR/hofx/scripts/merge.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
 exit $rc

--- a/src/hofx/rocoto/gdas_merge.sh
+++ b/src/hofx/rocoto/gdas_merge.sh
@@ -2,20 +2,8 @@
 
 set -eux
 
-export PYTHONPATH=$HOFX_HOMEDIR
-
-#---- other variables
-alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
-alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
-alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
-export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
-set -eux
+#---- setup runtime evironment
+source $HOFX_HOMEDIR/hofx/cfg/setup
 
 #---- execute merge
 $HOFX_HOMEDIR/hofx/scripts/merge.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE

--- a/src/hofx/rocoto/gdas_stage.sh
+++ b/src/hofx/rocoto/gdas_stage.sh
@@ -2,20 +2,8 @@
 
 set -eux
 
-export PYTHONPATH=$HOFX_HOMEDIR
-
-#---- other variables
-alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
-alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
-alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
-export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
-set -eux
+#---- setup runtime evironment
+source $HOFX_HOMEDIR/hofx/cfg/setup
 
 #---- execute stage
 $HOFX_HOMEDIR/hofx/scripts/stage.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE

--- a/src/hofx/rocoto/gdas_stage.sh
+++ b/src/hofx/rocoto/gdas_stage.sh
@@ -4,6 +4,20 @@ set -eux
 
 export PYTHONPATH=$HOFX_HOMEDIR
 
+#---- other variables
+alias source_yaml=$HOFX_HOMEDIR/hofx/bin/source_yaml
+alias create_bundle=$HOFX_HOMEDIR/hofx/bin/create_bundle
+alias detect_host=$HOFX_HOMEDIR/hofx/bin/detect_host
+shopt -s expand_aliases
+
+#---- get machine and setup runtime environment
+set +eux
+machine=${machine:-$(detect_host)}
+source $HOFX_HOMEDIR/hofx/cfg/platform/$machine/JEDI
+export R2D2_CONFIG=$HOFX_HOMEDIR/hofx/cfg/platform/$machine/r2d2_config.yaml
+set -eux
+
+#---- execute stage
 $HOFX_HOMEDIR/hofx/scripts/stage.sh $HOFX_HOMEDIR/hofx/cfg/expdir $ROTDIR/hofx_tmp/$CDATE
 rc=$?
 exit $rc

--- a/src/hofx/scripts/archive.sh
+++ b/src/hofx/scripts/archive.sh
@@ -17,17 +17,6 @@ WORKDIR=$2
 MYPATH=`readlink -f "$0"`
 MYDIR=`dirname "$MYPATH"`
 gitdir=$MYDIR/..
-alias source_yaml=$gitdir/bin/source_yaml
-alias create_bundle=$gitdir/bin/create_bundle
-alias detect_host=$gitdir/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $gitdir/cfg/platform/$machine/JEDI
-export R2D2_CONFIG=$gitdir/cfg/platform/$machine/r2d2_config.yaml
-set -eux
 
 mkdir -p $WORKDIR
 cd $WORKDIR

--- a/src/hofx/scripts/diags.sh
+++ b/src/hofx/scripts/diags.sh
@@ -17,17 +17,6 @@ WORKDIR=$2
 MYPATH=`readlink -f "$0"`
 MYDIR=`dirname "$MYPATH"`
 gitdir=$MYDIR/..
-alias source_yaml=$gitdir/bin/source_yaml
-alias create_bundle=$gitdir/bin/create_bundle
-alias detect_host=$gitdir/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $gitdir/cfg/platform/$machine/hofxdiag
-export R2D2_CONFIG=$gitdir/cfg/platform/$machine/r2d2_config.yaml
-set -eux
 
 mkdir -p $WORKDIR
 cd $WORKDIR

--- a/src/hofx/scripts/hofx.sh
+++ b/src/hofx/scripts/hofx.sh
@@ -17,29 +17,6 @@ WORKDIR=$2
 MYPATH=`readlink -f "$0"`
 MYDIR=`dirname "$MYPATH"`
 gitdir=$MYDIR/..
-alias source_yaml=$gitdir/bin/source_yaml
-alias create_bundle=$gitdir/bin/create_bundle
-alias detect_host=$gitdir/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $gitdir/cfg/platform/$machine/JEDI
-export R2D2_CONFIG=$gitdir/cfg/platform/$machine/r2d2_config.yaml
-set -eux
-eval $(source_yaml ${USERYAML}/experiment.yaml account)
-
-#---- setup variables based on scheduler
-RUN_ENVIR=${RUN_ENVIR:-""}
-if [[ "$RUN_ENVIR" != "rocoto" ]]; then
-  export SLURM_ACCOUNT=$account
-  export SALLOC_ACCOUNT=$SLURM_ACCOUNT
-  export SBATCH_ACCOUNT=$SLURM_ACCOUNT
-  export SLURM_QOS=debug
-  nprocs=24
-  APRUN="srun -n ${nprocs} --ntasks-per-node=3 -t 30:00"
-fi
 
 mkdir -p $WORKDIR
 cd $WORKDIR
@@ -49,6 +26,6 @@ export CDATE=${CDATE:-2020121500}
 $gitdir/bin/genYAML hofx $USERYAML $WORKDIR/hofx.yaml
 
 #---- run executable
-eval $(source_yaml ${USERYAML}/experiment.yaml jedi_build)
+eval $($gitdir/bin/source_yaml ${USERYAML}/experiment.yaml jedi_build)
 ${APRUN} $jedi_build/bin/fv3jedi_hofx_nomodel.x $WORKDIR/hofx.yaml
 

--- a/src/hofx/scripts/merge.sh
+++ b/src/hofx/scripts/merge.sh
@@ -17,17 +17,6 @@ WORKDIR=$2
 MYPATH=`readlink -f "$0"`
 MYDIR=`dirname "$MYPATH"`
 gitdir=$MYDIR/..
-alias source_yaml=$gitdir/bin/source_yaml
-alias create_bundle=$gitdir/bin/create_bundle
-alias detect_host=$gitdir/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $gitdir/cfg/platform/$machine/JEDI
-export R2D2_CONFIG=$gitdir/cfg/platform/$machine/r2d2_config.yaml
-set -eux
 
 mkdir -p $WORKDIR
 cd $WORKDIR

--- a/src/hofx/scripts/stage.sh
+++ b/src/hofx/scripts/stage.sh
@@ -17,17 +17,6 @@ WORKDIR=$2
 MYPATH=`readlink -f "$0"`
 MYDIR=`dirname "$MYPATH"`
 gitdir=$MYDIR/..
-alias source_yaml=$gitdir/bin/source_yaml
-alias create_bundle=$gitdir/bin/create_bundle
-alias detect_host=$gitdir/bin/detect_host
-shopt -s expand_aliases
-
-#---- get machine and setup runtime environment
-set +eux
-machine=${machine:-$(detect_host)}
-source $gitdir/cfg/platform/$machine/JEDI
-export R2D2_CONFIG=$gitdir/cfg/platform/$machine/r2d2_config.yaml
-set -eux
 
 mkdir -p $WORKDIR
 cd $WORKDIR


### PR DESCRIPTION
The PR is opened to request merger of `feature/clean_refactor` into `develop`.   `feature/clean_refactor` contains the following changes with respect to `develop`
- replace use of unix `grep`, `cut`, `head `commands with `source_yaml`
- move shared setup of runtime environment in scripts to a single setup file, `src/hofx/cfg/setup`, which is sourced by rocoto jobs.
- move job specific runtime environment setup from scripts to corresponding rocoto jobs

Additional information regarding these changes is found in issue #37.

These changes have been tested in a short parallel covering 2020121500 through 2020121600.  The above changes do not alter results.   