### PR TITLE
Bug fix for satbias cycle file time in R2D2 fetch

### DIFF
--- a/src/hofx/stage.py
+++ b/src/hofx/stage.py
@@ -103,12 +103,13 @@ def obs(config):
         )
         # try to grab bias correction files too
         if 'obs bias' in ob:
+            bkg_time = Hour(config['cycle']) - DateIncrement(config['step_cycle'])
             satbias = ob['obs bias']['input file']
             fetch(
                 type='bc',
                 provider=config['obs']['bc_src'],
                 experiment=config['obs']['bc_dump'],
-                date=config['cycle'],
+                date=bkg_time,
                 obs_type=obname,
                 target_file=satbias,
                 file_type='satbias',
@@ -123,7 +124,7 @@ def obs(config):
                 type='bc',
                 provider=config['obs']['bc_src'],
                 experiment=config['obs']['bc_dump'],
-                date=config['cycle'],
+                date=bkg_time,
                 obs_type=obname,
                 target_file=tlapse,
                 file_type='tlapse',


### PR DESCRIPTION
The R2D2 fetch command was incorrectly grabbing the sat bias file from the current cycle and saving it in the run/stage directory with the timestamp of the previous cycle, thus appearing like it was correct. 

This PR fixes the R2D2 command to grab the correct (previous cycle) file and stage it with the same name as before.