### PR TITLE
Update to modulefiles for Orion

### DIFF
--- a/src/hofx/cfg/platform/orion/JEDI
+++ b/src/hofx/cfg/platform/orion/JEDI
@@ -1,5 +1,5 @@
 module purge
-export JEDI_OPT=/work/noaa/da/grubin/opt/modules
+export JEDI_OPT=/work/noaa/da/jedipara/opt/modules
 module use $JEDI_OPT/modulefiles/core
 module load jedi/intel-impi
 module unload python

--- a/src/hofx/cfg/platform/orion/hofxdiag
+++ b/src/hofx/cfg/platform/orion/hofxdiag
@@ -1,5 +1,5 @@
 module purge
-export JEDI_OPT=/work/noaa/da/grubin/opt/modules
+export JEDI_OPT=/work/noaa/da/jedipara/opt/modules
 module use $JEDI_OPT/modulefiles/core
 module load jedi/intel-impi
 module unload python


### PR DESCRIPTION
JCSDA deprecated the modulefiles in R Grubin's directory for `jedipara`. This changes the workflow to load the new ones instead.